### PR TITLE
Minor fix to python code and GATK in/out files. 

### DIFF
--- a/bin/generatevcf
+++ b/bin/generatevcf
@@ -245,8 +245,8 @@ if [ $runstep2 == 1 ] ; then
 
 	# The GATK tool Haplotype Caller is used to compare the bam file with the reference genome and generate a gvcf file
 	cd ${workingdir}
-	echo "$gatk ${haplotypecallerOptions} -R ${reference}/IRGSP-1.0_genome.fasta -I $bamfiledir/${cultivar}.realigned.bam -o ${outputdir}/vcffiles/${cultivar}.g.vcf -nct ${nct}"
-	$gatk ${haplotypecallerOptions} -R ${reference}/IRGSP-1.0_genome.fasta -I $bamfiledir/${cultivar}.realigned.bam -o ${outputdir}/vcffiles/${cultivar}.g.vcf -nct ${nct}
+	echo "$gatk ${haplotypecallerOptions} -R ${reference}/IRGSP-1.0_genome.fasta -I $bamfiledir/${cultivar}.realigned.bam -o ${outputdir}/vcffiles/${cultivar}.g.vcf.gz -nct ${nct}"
+	$gatk ${haplotypecallerOptions} -R ${reference}/IRGSP-1.0_genome.fasta -I $bamfiledir/${cultivar}.realigned.bam -o ${outputdir}/vcffiles/${cultivar}.g.vcf.gz -nct ${nct}
 	echo "GVCF file created"
 	echo ""
 fi
@@ -262,9 +262,8 @@ if [ $runstep3 == 1 ] ; then
 	# The option -allSites is necessary for our purposes, so that called sites that match the reference 
 	# will be able to be compared to SNPs in other cultivars.
 	cd ${workingdir}
-	$gatk ${genotypegvcfsOptions} -R ${reference}/IRGSP-1.0_genome.fasta -V ${outputdir}/vcffiles/${cultivar}.g.vcf -o ${outputdir}/vcffiles/${cultivar}.full.vcf -nt ${nt}
-	cd ${outputdir}/vcffiles
-        bgzip ${cultivar}.full.vcf && tabix -f ${cultivar}.full.vcf.gz
+	echo "$gatk ${genotypegvcfsOptions} -R ${reference}/IRGSP-1.0_genome.fasta -V ${outputdir}/vcffiles/${cultivar}.g.vcf.gz -o ${outputdir}/vcffiles/${cultivar}.full.vcf.gz -nt ${nt}"
+	$gatk ${genotypegvcfsOptions} -R ${reference}/IRGSP-1.0_genome.fasta -V ${outputdir}/vcffiles/${cultivar}.g.vcf.gz -o ${outputdir}/vcffiles/${cultivar}.full.vcf.gz -nt ${nt}
 	echo "VCF file created"
 	echo ""
 fi

--- a/bin/generatevcf
+++ b/bin/generatevcf
@@ -263,6 +263,8 @@ if [ $runstep3 == 1 ] ; then
 	# will be able to be compared to SNPs in other cultivars.
 	cd ${workingdir}
 	$gatk ${genotypegvcfsOptions} -R ${reference}/IRGSP-1.0_genome.fasta -V ${outputdir}/vcffiles/${cultivar}.g.vcf -o ${outputdir}/vcffiles/${cultivar}.full.vcf -nt ${nt}
+	cd ${outputdir}/vcffiles
+        bgzip ${cultivar}.full.vcf && tabix -f ${cultivar}.full.vcf.gz
 	echo "VCF file created"
 	echo ""
 fi
@@ -278,7 +280,6 @@ if [ $runstep4 == 1 ] ; then
 	# It is also expedient to split the VCF by chromosome so that merges can be performed with some degree of parallelism.
 	# This step is not necessary if a merge is not planned.
 	cd ${outputdir}/vcffiles
-        bgzip ${cultivar}.full.vcf && tabix -f ${cultivar}.full.vcf.gz
 	#TODO Make this more sensible about parallelizing. As is, it will be really inefficient on a machine with fewer than 12 processors
         for chromosome in chr{01,02,03,04,05,06,07,08,09,10,11,12}; do (
                 bcftools view --exclude-uncalled --exclude-types 'indels' --genotype ^het -r ${chromosome} -O v ${cultivar}.full.vcf.gz | awk ' /^#/ {print} length($4) == 1 && ( ($5 != "<NON_REF>") || ($0 !~ /1\/1/) ) && ( ($5 !~ /^[ACGT],<NON_REF>/) || ($0 !~ /2\/2/) ) && ( ($5 !~ /^[ATCG],[ATCG],<NON_REF>/) || ($0 !~ /3\/3/) ) && ( ($5 !~ /^[ACGT],[ATCG],[ATCG],<NON_REF>/) || ($0 !~ /4\/4/) ) {print} ' | bgzip -c > ../splitchromosomefiles/${cultivar}.${chromosome}.noindels_nohets_nomnps.vcf.gz; tabix ../splitchromosomefiles/${cultivar}.${chromosome}.noindels_nohets_nomnps.vcf.gz) &

--- a/bin/snp2seq.py
+++ b/bin/snp2seq.py
@@ -28,7 +28,7 @@ def vcf_to_fasta(input_file_name):
                 sequences_dict[sample.sample].append(sample.gt_bases[0]) # This is taking the first base only. Adjust this if the input isn't heterozygous.
         #print("sequences_dict:")
         #print(sequences_dict)
-        bunch = [ SeqRecord(Seq("".join(sequences_dict[cultivar])), cultivar) for cultivar in sequences_dict]
+        bunch = [ SeqRecord(Seq("".join(sequences_dict[cultivar])), cultivar, description='') for cultivar in sequences_dict]
         #print("bunch: ")
         #print(bunch)
         SeqIO.write(bunch, input_file_name + ".fasta", "fasta")


### PR DESCRIPTION
All GATK input and output files are now in compressed format; no need to make extra steps to compress files.

Fixed a potential bug where python code generates FASTA files with extra '>' sign in the name. I had this issue when I've tried to split some sequences and could not do it properly due to the extra '>' identifier. 